### PR TITLE
Refactor storage of ban reasons

### DIFF
--- a/extras/db.sql
+++ b/extras/db.sql
@@ -1,7 +1,7 @@
 /*
 The RealistikOsu Database Structure.
 This is a Ripple based db schema around which USSR was designed.
-Dump: 17/5/22
+Dump: 20/6/22
 */
 
 CREATE TABLE `achievements` (
@@ -856,9 +856,22 @@ CREATE TABLE user_pinned (
 
 ALTER TABLE `user_pinned` ADD INDEX(`userid`);
 
---
--- Indexes for dumped tables
---
+CREATE TABLE `ban_logs` (
+  `id` int(11) NOT NULL,
+  `from_id` int(11) NOT NULL,
+  `to_id` int(11) NOT NULL,
+  `ts` datetime NOT NULL,
+  `summary` varchar(256) NOT NULL,
+  `detail` varchar(2048) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `ban_logs`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `to_id` (`to_id`);
+
+ALTER TABLE `ban_logs`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
 
 --
 -- Indexes for table `achievements`


### PR DESCRIPTION
This PR aims to overhaul the way ban/restriction reasons are stored witin the database. Currently, a mixture of two weird systems are used, with a per-user notes field and a ban_reason field within the database. This requires a lot of maintenence work by staff, moving data between the two fields and is hard to interface with programatically.

This system aims to solve this by allowing each ban alongside the info around it to be its own separate entry within the database, including all of the necessary info in one.