### PR TITLE
Replays not saving with the correct prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ config.json
 .vscode/
 test_data/
 .data/
+*.sum

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -38,7 +38,7 @@ async def get_replay(
     if mode.autopilot:
         replay_path = app.utils.AUTOPILOT_REPLAYS
 
-    replay_file = replay_path / f"{score_id}.osr"
+    replay_file = replay_path / f"replay_{score_id}.osr"
     if not replay_file.exists():
         logger.error(f"Requested replay ID {score_id}, but no file could be found")
         return b"error: no"

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -259,7 +259,7 @@ async def submit_score(
                 "a replay editor. (score submit gate)",
             )
         else:
-            replay_file = replay_path / f"{score.id}.osr"
+            replay_file = replay_path / f"replay_{score.id}.osr"
             replay_file.write_bytes(replay_data)
 
     asyncio.create_task(app.usecases.beatmap.increment_playcount(beatmap))

--- a/app/usecases/score.py
+++ b/app/usecases/score.py
@@ -198,7 +198,7 @@ async def build_full_replay(score: Score) -> Optional[BinaryWriter]:
     if score.mode.autopilot:
         replay_path = app.utils.AUTOPILOT_REPLAYS
 
-    replay_file = replay_path / f"{score.id}.osr"
+    replay_file = replay_path / f"replay_{score.id}.osr"
     if not replay_file.exists():
         return
 

--- a/migrations/001-country-row/go.sum
+++ b/migrations/001-country-row/go.sum
@@ -1,0 +1,7 @@
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
+github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/migrations/001-country-row/go.sum
+++ b/migrations/001-country-row/go.sum
@@ -1,7 +1,0 @@
-github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
-github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
-github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/migrations/002-replay-prefixes/README.md
+++ b/migrations/002-replay-prefixes/README.md
@@ -1,0 +1,19 @@
+# Replay Prefix Adder
+This is a simple utility made to fix a bug caused by the 19/6/22 rewrite where new replays
+would me named incorrectly.
+
+## Requirements
+This migration has the same exact requirements as USSR itself.
+- Python >=3.8
+- A previously generated USSR config with correct paths set.
+
+## Running the migrator
+To run this migrator, just run the command
+```sh
+python3 main.py
+```
+replacing `python3` with your corresponding python executable.
+
+## Important note!
+Do not move the main.py from its directory! This is because the migration makes a few assumptions based on the
+current working directory, meaning your file structure may not match up if its moved.

--- a/migrations/002-replay-prefixes/main.py
+++ b/migrations/002-replay-prefixes/main.py
@@ -57,7 +57,8 @@ def main() -> int:
 
         # Find all replays to rename.
         rename_replays = filter(
-            lambda x: not x.startswith("replay_"), glob.glob("*.osr"),
+            lambda x: not x.startswith("replay_"),
+            glob.glob("*.osr"),
         )
 
         for replay_name in rename_replays:

--- a/migrations/002-replay-prefixes/main.py
+++ b/migrations/002-replay-prefixes/main.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import os
+from typing import Any
+
+CONFIG_PATH = "config.json"
+REPLAY_PREFIXES = (
+    "",
+    "_relax",
+    "_ap",
+)
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def set_cwd() -> None:
+    """Sets the CWD to the root USSR dir."""
+
+    os.chdir("../../")
+
+
+def determine_full_path(path: str) -> str:
+    return os.path.join(os.getcwd(), path) if not path.startswith("/") else path
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+    )
+    set_cwd()
+    if not os.path.exists(CONFIG_PATH):
+        logging.error(
+            "The config file was not found! Make sure you have generated "
+            "it prior to using this migration.",
+        )
+        return 1
+
+    config = load_json(CONFIG_PATH)
+    logging.info("Config successfully loaded!")
+
+    data_dir = determine_full_path(config["data_dir"])
+    if not os.path.exists(data_dir):
+        logging.error("The data directory within the config file was not found!")
+        return 1
+
+    # Search for misnamed replays.
+    for prefix in REPLAY_PREFIXES:
+        replay_path = os.path.join(data_dir, "replays" + prefix)
+        logging.info(f"Setting CWD to {replay_path}")
+        os.chdir(replay_path)
+
+        # Find all replays to rename.
+        rename_replays = filter(
+            lambda x: not x.startswith("replay_"), glob.glob("*.osr"),
+        )
+
+        for replay_name in rename_replays:
+            new_name = f"replay_{replay_name}"
+            logging.info(f"Renaming {replay_name} -> {new_name}")
+            os.rename(replay_name, new_name)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The new rewrite has caused an issue where replays are saved and read with an incorrect filename, ommiting the `replay_` prefix from the old USSR and LETS versions. This PR aims to resolve this, alongside adding a migration utility to clean up replays saved during the time period this was unaccounted for.