### PR TITLE
Fix score overwrite for restricted users

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -299,9 +299,10 @@ async def submit_score(
     await app.usecases.stats.refresh_stats(user.id)
 
     if score.status == ScoreStatus.BEST:
-        score.rank = await leaderboard.find_score_rank(score.id)
+        score.rank = await leaderboard.find_score_rank(score.user_id, score.id)
     elif score.status == ScoreStatus.SUBMITTED:
         score.rank = await leaderboard.whatif_placement(
+            user.id,
             score.pp if score.mode > Mode.MANIA else score.score,
         )
 

--- a/app/objects/leaderboard.py
+++ b/app/objects/leaderboard.py
@@ -89,7 +89,9 @@ class Leaderboard:
 
         self.scores = sorted(self.scores, key=sort, reverse=True)
 
-    async def whatif_placement(self, user_id: int, sort_value: Union[int, float]) -> int:
+    async def whatif_placement(
+        self, user_id: int, sort_value: Union[int, float],
+    ) -> int:
         unrestricted_scores = await self.get_unrestricted_scores(user_id)
 
         for idx, score in enumerate(unrestricted_scores):


### PR DESCRIPTION
This pull request is a replication of a similar commit (https://github.com/osuAkatsuki/LESS/commit/c030904b8c51432bcfe25b2307ae7c5e5adefbd9) that fixes an issue where scores of restricted users would always be overwritten.