### PR TITLE
Re-enable convert performance points

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -173,10 +173,7 @@ async def submit_score(
         beatmap.id,
         beatmap.md5,
     ):
-        if beatmap.mode.as_vn == score.mode.as_vn:
-            # only get pp if the map is not a convert
-            # convert support will come later
-            app.usecases.performance.calculate_score(score, osu_file_path)
+        app.usecases.performance.calculate_score(score, osu_file_path)
 
         if score.passed:
             old_best = await leaderboard.find_user_score(user.id)

--- a/app/usecases/performance.py
+++ b/app/usecases/performance.py
@@ -125,8 +125,8 @@ def calculate_performance(
 ) -> tuple[float, float]:
 
     calc_func = calculate_oppai if (mode.relax or mode.autopilot) and mode.as_vn == 0 \
-        else calculate_rosu;
-    return calc_func(mode, mods, max_combo, acc, nmiss, osu_file_path);
+        else calculate_rosu
+    return calc_func(mode, mods, max_combo, acc, nmiss, osu_file_path)
 
 
 def calculate_score(score: Score, osu_file_path: Path) -> None:

--- a/app/usecases/performance.py
+++ b/app/usecases/performance.py
@@ -84,6 +84,7 @@ def calculate_oppai(
 
 
 def calculate_rosu(
+    mode: Mode,
     mods: int,
     max_combo: int,
     score: int,
@@ -93,6 +94,7 @@ def calculate_rosu(
 ) -> tuple[float, float]:
     calculator = Calculator(str(osu_file_path))
     params = ScoreParams(
+        mode=mode.value,
         mods=mods,
         combo=max_combo,
         score=score,
@@ -121,10 +123,10 @@ def calculate_performance(
     nmiss: int,
     osu_file_path: Path,
 ) -> tuple[float, float]:
-    if (mode.relax or mode.autopilot) and mode.as_vn == 0:
-        return calculate_oppai(mode, mods, max_combo, acc, nmiss, osu_file_path)
-    else:
-        return calculate_rosu(mods, max_combo, score, acc, nmiss, osu_file_path)
+
+    calc_func = calculate_oppai if (mode.relax or mode.autopilot) and mode.as_vn == 0 \
+        else calculate_rosu;
+    return calc_func(mode, mods, max_combo, acc, nmiss, osu_file_path);
 
 
 def calculate_score(score: Score, osu_file_path: Path) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ databases[asyncmy]
 fastapi
 orjson
 py3rijndael
-rosu-pp-py
+# Specifying this version is important
+rosu-pp-py==0.6.0
 uvicorn
 uvloop


### PR DESCRIPTION
The newest rosu-pp version (0.6.0) introduces convert support. This means that convert pp can be reasonably re-added into USSR.

Note:
- Requires testing on whether rosu-pp accepts integer mode enums.