### PR TITLE
Remove ScoreV2 as a rankable mod.

### DIFF
--- a/app/constants/mods.py
+++ b/app/constants/mods.py
@@ -96,10 +96,7 @@ class Mods(IntFlag):
         return False
 
 
-UNRANKABLE_MODS = (
-    Mods.AUTOPLAY
-    | Mods.SCOREV2
-)
+UNRANKABLE_MODS = Mods.AUTOPLAY | Mods.SCOREV2
 
 str_mods = {
     Mods.NOFAIL: "NF",

--- a/app/constants/mods.py
+++ b/app/constants/mods.py
@@ -80,7 +80,7 @@ class Mods(IntFlag):
     def rankable(self) -> bool:
         """Checks if the mod combo is rank-worthy."""
 
-        return self not in UNRANKABLE_MODS
+        return self & UNRANKABLE_MODS == Mods.NOMOD
 
     @property
     def conflict(self) -> bool:
@@ -97,8 +97,8 @@ class Mods(IntFlag):
 
 
 UNRANKABLE_MODS = (
-    Mods.AUTOPLAY,
-    Mods.SCOREV2,
+    Mods.AUTOPLAY
+    | Mods.SCOREV2
 )
 
 str_mods = {

--- a/app/constants/mods.py
+++ b/app/constants/mods.py
@@ -80,10 +80,7 @@ class Mods(IntFlag):
     def rankable(self) -> bool:
         """Checks if the mod combo is rank-worthy."""
 
-        if self & Mods.AUTOPLAY:
-            return False
-
-        return True
+        return self not in UNRANKABLE_MODS
 
     @property
     def conflict(self) -> bool:
@@ -98,6 +95,11 @@ class Mods(IntFlag):
 
         return False
 
+
+UNRANKABLE_MODS = (
+    Mods.AUTOPLAY,
+    Mods.SCOREV2,
+)
 
 str_mods = {
     Mods.NOFAIL: "NF",

--- a/migrations/003-delete-scorev2-scores/README.md
+++ b/migrations/003-delete-scorev2-scores/README.md
@@ -1,0 +1,3 @@
+# ScoreV2 score remover
+This simple migration aims to correct a bug with USSR where scores with the "ScoreV2" mod would be allowed to submit.
+This is due to it completely changing the scoring mechanic, disrupting all score based leaderboards.

--- a/migrations/003-delete-scorev2-scores/migration.sql
+++ b/migrations/003-delete-scorev2-scores/migration.sql
@@ -1,0 +1,4 @@
+-- Delete all scores with ScoreV2
+DELETE FROM scores WHERE mods & 536870912;
+DELETE FROM scores_relax WHERE mods & 536870912;
+DELETE FROM scores_ap WHERE mods & 536870912;


### PR DESCRIPTION
Since the rewrite (or even earlier), score V2 has been allowed on the leaderboards. This is a major oversight due to its radical changes to the scoring system, which are incompatible with all other mods. This causes major discrepancies within score leaderboards.