### PR TITLE
Recalculation based pubsubs

### DIFF
--- a/app/redis.py
+++ b/app/redis.py
@@ -12,6 +12,7 @@ import app.state
 import app.usecases
 import logger
 from app.constants.ranked_status import RankedStatus
+from app.constants.mode import Mode
 
 PUBSUB_HANDLER = Callable[[str], Awaitable[None]]
 
@@ -89,6 +90,38 @@ async def handle_clan_change(payload: str) -> None:
     await app.usecases.clans.update_clan(user_id)
 
     logger.info(f"Updated clan for user ID {user_id}")
+
+@register_pubsub("ussr:recalculate_user")
+async def handle_user_recalculate(payload: str) -> None:
+    user_id = int(payload)
+
+    for mode in Mode:
+        stats = await app.usecases.stats.fetch(user_id, mode)
+        if stats is None:
+            logger.warning(f"Attempted to recalculate stats for user {user_id} but they don't exist!")
+            return
+        await app.usecases.stats.full_recalc(stats)
+        await app.usecases.stats.save(stats)
+
+    logger.info(f"Recalculated user ID {user_id}")
+
+@register_pubsub("ussr:recalculate_user_full")
+async def handle_user_recalculate_full(payload: str) -> None:
+    user_id = int(payload)
+
+    for mode in Mode:
+        stats = await app.usecases.stats.fetch(user_id, mode)
+        if stats is None:
+            logger.warning(f"Attempted to recalculate stats for user {user_id} but they don't exist!")
+            return
+        await app.usecases.stats.full_recalc(stats)
+        await app.usecases.stats.calc_playcount(stats)
+        await app.usecases.stats.calc_max_combo(stats)
+        await app.usecases.stats.calc_total_score(stats)
+        await app.usecases.stats.calc_ranked_score(stats)
+        await app.usecases.stats.save(stats)
+
+    logger.info(f"Recalculated user ID {user_id}")
 
 
 class RedisMessage(TypedDict):

--- a/app/redis.py
+++ b/app/redis.py
@@ -11,8 +11,8 @@ import orjson
 import app.state
 import app.usecases
 import logger
-from app.constants.ranked_status import RankedStatus
 from app.constants.mode import Mode
+from app.constants.ranked_status import RankedStatus
 
 PUBSUB_HANDLER = Callable[[str], Awaitable[None]]
 
@@ -91,6 +91,7 @@ async def handle_clan_change(payload: str) -> None:
 
     logger.info(f"Updated clan for user ID {user_id}")
 
+
 @register_pubsub("ussr:recalculate_user")
 async def handle_user_recalculate(payload: str) -> None:
     user_id = int(payload)
@@ -98,12 +99,15 @@ async def handle_user_recalculate(payload: str) -> None:
     for mode in Mode:
         stats = await app.usecases.stats.fetch(user_id, mode)
         if stats is None:
-            logger.warning(f"Attempted to recalculate stats for user {user_id} but they don't exist!")
+            logger.warning(
+                f"Attempted to recalculate stats for user {user_id} but they don't exist!",
+            )
             return
         await app.usecases.stats.full_recalc(stats)
         await app.usecases.stats.save(stats)
 
     logger.info(f"Recalculated user ID {user_id}")
+
 
 @register_pubsub("ussr:recalculate_user_full")
 async def handle_user_recalculate_full(payload: str) -> None:
@@ -112,7 +116,9 @@ async def handle_user_recalculate_full(payload: str) -> None:
     for mode in Mode:
         stats = await app.usecases.stats.fetch(user_id, mode)
         if stats is None:
-            logger.warning(f"Attempted to recalculate stats for user {user_id} but they don't exist!")
+            logger.warning(
+                f"Attempted to recalculate stats for user {user_id} but they don't exist!",
+            )
             return
         await app.usecases.stats.full_recalc(stats)
         await app.usecases.stats.calc_playcount(stats)

--- a/app/usecases/performance.py
+++ b/app/usecases/performance.py
@@ -41,7 +41,7 @@ async def check_local_file(osu_file_path: Path, map_id: int, map_md5: str) -> bo
         ) as response:
             if response.status != 200:
                 return False
-            
+
             res_bytes = await response.read()
             if b"osu file format" not in res_bytes:
                 return False

--- a/app/usecases/stats.py
+++ b/app/usecases/stats.py
@@ -161,6 +161,7 @@ async def update_rank(stats: Stats) -> None:
 async def refresh_stats(user_id: int) -> None:
     await app.state.services.redis.publish("peppy:update_cached_stats", user_id)
 
+
 async def calc_playcount(stats: Stats) -> int:
     stats.playcount = await app.state.services.database.fetch_val(
         f"SELECT COUNT(*) FROM {stats.mode.scores_table} WHERE userid = :id AND play_mode = :mode",
@@ -168,6 +169,7 @@ async def calc_playcount(stats: Stats) -> int:
     )
 
     return stats.playcount
+
 
 async def calc_max_combo(stats: Stats) -> int:
     stats.max_combo = await app.state.services.database.fetch_val(
@@ -178,6 +180,7 @@ async def calc_max_combo(stats: Stats) -> int:
 
     return stats.max_combo
 
+
 async def calc_total_score(stats: Stats) -> int:
     stats.total_score = await app.state.services.database.fetch_val(
         f"SELECT SUM(score) FROM {stats.mode.scores_table} WHERE userid = :id "
@@ -186,6 +189,7 @@ async def calc_total_score(stats: Stats) -> int:
     )
 
     return stats.total_score
+
 
 async def calc_ranked_score(stats: Stats) -> int:
     stats.ranked_score = await app.state.services.database.fetch_val(

--- a/migrations/004-remove-invalid-osu/main.py
+++ b/migrations/004-remove-invalid-osu/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import os
 


### PR DESCRIPTION
Expands the recalculation capabilities, offering a redis api for access.

Adds the pubsubs:
`ussr:recalculate_user` - Performs a PP and accuracy recalculation.
`ussr:recalculate_user_full` - Recalculates the users pp, acc, max combo, total score and ranked score.