### PR TITLE
Remove verified badge cache

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -236,15 +236,17 @@ async def submit_score(
             score.mode,
             score.mods & Mods.FLASHLIGHT != 0,
         )
-        and not await app.usecases.verified.get_verified(user.id)
     ):
-        await restrict_user(
-            user,
-            f"Surpassing PP cap as unverified!",
-            "The user attempted to submit a score with PP higher than the "
-            f"PP cap. {beatmap.song_name} +{score.mods!r} ({score.pp:.2f}pp)"
-            f" ID: {score.id} (score submit gate)",
-        )
+        # Separated from the previous clause to only call the pp cap function
+        # when necessary.
+        if not await app.usecases.verified.get_verified(user.id):
+            await restrict_user(
+                user,
+                f"Surpassing PP cap as unverified!",
+                "The user attempted to submit a score with PP higher than the "
+                f"PP cap. {beatmap.song_name} +{score.mods!r} ({score.pp:.2f}pp)"
+                f" ID: {score.id} (score submit gate)",
+            )
 
     if score.status == ScoreStatus.BEST:
         await app.state.services.database.execute(

--- a/app/init_api.py
+++ b/app/init_api.py
@@ -45,7 +45,6 @@ def init_events(asgi_app: FastAPI) -> None:
             app.usecases.usernames.update_usernames_task,
             app.usecases.countries.update_countries_task,
             app.usecases.clans.update_clans_task,
-            app.usecases.verified.update_verified_task,
             app.usecases.pp_cap.update_pp_cap_task,
         ):
             task = asyncio.create_task(_task())

--- a/app/usecases/verified.py
+++ b/app/usecases/verified.py
@@ -1,53 +1,13 @@
 from __future__ import annotations
 
-import asyncio
-
 import app.state
 import logger
 from config import config
 
-VERIFIED: dict[int, bool] = {}
-FIVE_MINUTES = 60 * 5
-
 
 async def get_verified(user_id: int) -> bool:
-    if user_id in VERIFIED:
-        return VERIFIED[user_id]
-
-    has_badge = await app.state.services.database.fetch_val(
+    return await app.state.services.database.fetch_val(
         "SELECT 1 FROM user_badges WHERE user = :uid AND badge = :bid",
         {"uid": user_id, "bid": config.srv_verified_badge},
     )
 
-    if not has_badge:
-        has_badge = False
-
-    VERIFIED[user_id] = has_badge
-    return VERIFIED[user_id]
-
-
-async def load_verified() -> None:
-    # fetch all to store who don't have verified too
-    db_users = await app.state.services.database.fetch_all("SELECT id FROM users")
-
-    db_verified = await app.state.services.database.fetch_all(
-        "SELECT user FROM user_badges WHERE badge = :bid",
-        {"bid": config.srv_verified_badge},
-    )
-
-    verified = [b["user"] for b in db_verified]
-
-    for db_user in db_users:
-        result = False
-        if db_user["id"] in verified:
-            result = True
-
-        VERIFIED[db_user["id"]] = result
-
-    logger.info(f"Cached verified badges for {len(db_users)} users!")
-
-
-async def update_verified_task() -> None:
-    while True:
-        await load_verified()
-        await asyncio.sleep(FIVE_MINUTES)


### PR DESCRIPTION
This cache was often causing weird behaviour where verified users would still get restricted. This PR removes it completely, considering the query it was caching wasn't expensive at all regardless.